### PR TITLE
Removing some global fields from the Craft CMS

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -134,7 +134,7 @@
       
         <div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
         {% if craft.locale == 'es_us' %}
-          <h5><a href="http://subsplash.com/stanne/app" target="_blank">Â¡Descarga nuestras aplicaciones de telÃ©fono!</a></h5>
+          <h5><a href="https://subsplash.com/staana/app" target="_blank">ÁDescarga nuestras aplicaciones de telŽfono!</a></h5>
         {% else %}
           <h5><a href="http://subsplash.com/stanne/app" target="_blank">Download Our Parish Mobile Phone Apps!</a></h5>
         {% endif %}

--- a/templates/news/_entry.html
+++ b/templates/news/_entry.html
@@ -87,29 +87,17 @@
                 <p>{{ "Get the latest news and updates from St. Anne’s in your RSS feed or email inbox"|t }}!</p>
                 {% if craft.locale == 'es_us' %}
                 
-                    {% if feeds.announcementsFeedUrlSpanish is not empty %}
-                    <a href="{{ feeds.announcementsFeedUrlSpanish.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Announcements RSS"|t }}</a><br/>
-                    {% endif %}
-                    {% if feeds.eventsFeedUrlSpanish is not empty %}
-                    <a href="{{ feeds.eventsFeedUrlSpanish.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Events RSS"|t }}</a><br/>
-                    {% endif %}
+                    <a href="http://feeds.feedburner.com/AnunciosParaStaAna" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Announcements RSS"|t }}</a><br/>
+                    <a href="http://feeds.feedburner.com/EventosStaAna" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Events RSS"|t }}</a><br/>
                     <a href="http://feeds.feedburner.com/CalendarioDeStaAna" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Parish Calendar RSS"|t }}</a><br/>
-                    {% if feeds.podcastFeedUrlSpanish is not empty %}
-                    <a href="{{ feeds.podcastFeedUrlSpanish.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{ "Podcasts RSS"|t }}</a>
-                    {% endif %}
+                    <a href="http://feeds.feedburner.com/AudiosdeParroquiaStaAna" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{ "Podcasts RSS"|t }}</a>
                     
                 {% else %}
                 
-                    {% if feeds.announcementsFeedUrl is not empty %}
-                    <a href="{{ feeds.announcementsFeedUrl.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Announcements RSS"|t }}</a><br/>
-                    {% endif %}
-                    {% if feeds.eventsFeedUrl is not empty %}
-                    <a href="{{ feeds.eventsFeedUrl.url }}" class="btn btn-light-brown-border"><i class="fa fa-rss" target="_blank"></i> {{"Events RSS"|t }}</a><br/>
-                    {% endif %}
+                    <a href="http://feeds.feedburner.com/StAnneAnnouncements" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Announcements RSS"|t }}</a><br/>
+                    <a href="http://feeds.feedburner.com/StAnneEvents" class="btn btn-light-brown-border"><i class="fa fa-rss" target="_blank"></i> {{"Events RSS"|t }}</a><br/>
                     <a href="http://feeds.feedburner.com/StAnneRomanCatholicParishCalendar" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{"Parish Calendar RSS"|t }}</a><br/>
-                    {% if feeds.podcastRss is not empty %}
-                    <a href="{{ feeds.podcastRss.url }}" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{ "Podcasts RSS"|t }}</a>
-                    {% endif %}
+                    <a href="http://feeds.feedburner.com/stannecatholicpodcast" class="btn btn-light-brown-border" target="_blank"><i class="fa fa-rss"></i> {{ "Podcasts RSS"|t }}</a>
                 
                 {% endif %}
                 

--- a/templates/page/_types/eventsLanding.html
+++ b/templates/page/_types/eventsLanding.html
@@ -14,12 +14,9 @@
       </div>
       <div class="col-lg-7 col-md-7 col-sm-7 action-links" style="text-align:right">
         {% if craft.locale == "en_us" %}
-          {% if feeds.eventsFeedUrl is not empty %}
-            <a style="display:inline-block" href="{{ feeds.eventsFeedUrl.url }}" target="_blank"><i class="fa fa-rss"></i> {{ "Events RSS"|t }}</a>
-          {% endif %}
+            <a style="display:inline-block" href="http://feeds.feedburner.com/StAnneEvents" target="_blank"><i class="fa fa-rss"></i> {{ "Events RSS"|t }}</a>
         {% elseif craft.locale == "es_us" %}
-          {% if feeds.eventsFeedUrlSpanish is not empty %}
-            <a style="display:inline-block" href="{{ feeds.eventsFeedUrlSpanish.url }}" target="_blank"><i class="fa fa-rss"></i> {{ "Eventos RSS"|t }}</a>
+            <a style="display:inline-block" href="http://feeds.feedburner.com/EventosStaAna" target="_blank"><i class="fa fa-rss"></i> {{ "Eventos RSS"|t }}</a>
           {% endif %}
         {% endif %}
               

--- a/templates/page/_types/mediaLanding.html
+++ b/templates/page/_types/mediaLanding.html
@@ -20,13 +20,9 @@
             </div>
             <div class="col-lg-7 col-md-7 col-sm-7 action-links">
               {% if craft.locale == "en_us" %}
-                {% if feeds.podcastRss is not empty %}
-                  <a style="display:inline-block;padding:5px 0" href="{{ feeds.podcastRss.url }}" target="_blank"><i class="fa fa-rss"></i> {{ "Podcast RSS"|t }}:</a>
-                {% endif %}
+                  <a style="display:inline-block;padding:5px 0" href="http://feeds.feedburner.com/stannecatholicpodcast" target="_blank"><i class="fa fa-rss"></i> {{ "Podcast RSS"|t }}:</a>
               {% elseif craft.locale == "es_us" %}
-                {% if feeds.podcastFeedUrlSpanish is not empty %}
-                  <a style="display:inline-blockpadding:5px 0" href="{{ feeds.podcastFeedUrlSpanish.url }}" target="_blank"><i class="fa fa-rss"></i> {{ "Audios RSS"|t }}:</a>
-                {% endif %}
+                  <a style="display:inline-blockpadding:5px 0" href="http://feeds.feedburner.com/AudiosdeParroquiaStaAna" target="_blank"><i class="fa fa-rss"></i> {{ "Audios RSS"|t }}:</a>
               {% endif %}
               
               <form style="display:inline-block;text-align:left;" action="https://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open('https://feedburner.google.com/fb/a/mailverify?uri={% if craft.locale == 'es_us' %}AudiosdeParroquiaStaAna{% else %}stannecatholicpodcast{% endif %}', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true"> <div style="color:#888;padding:0 0 5px 5px">{{ "Would you like to receive podcast emails?"|t }}</div><input type="text" style="margin:0 10px 0 5px;vertical-align:middle;width:160px" name="email" placeholder="{{ "Enter your email"|t }}...." title="{{ "Enter your email address"|t }}"/><input type="hidden" value="{% if craft.locale == 'es_us' %}AudiosdeParroquiaStaAna{% else %}stannecatholicpodcast{% endif %}" name="uri"/><input type="hidden" name="loc" value="en_US"/><button type="submit" class="btn btn-sm btn-light-blue" style="vertical-align:middle;"><i class="fa fa-check"></i> {{ "Subscribe"|t }}</button></form>


### PR DESCRIPTION
Since they are only being used on one template and they never change
values, it doesn’t really make much sense to make Craft load them for
the whole website in this way.