### PR TITLE
Removing the Slugify plugin.

### DIFF
--- a/templates/page/_types/contactUs.html
+++ b/templates/page/_types/contactUs.html
@@ -117,8 +117,8 @@
                     {% for service in siteWideSocialLinks.socialLinks %}
                       {% set link = service.serviceUrl %}
                         <li>
-                          <a href="{{ link.url }}" class="bg-{{ service.service | slugify }}">
-                            <i class='fa fa-{{ service.service | slugify }}'></i>
+                          <a href="{{ link.url }}" class="bg-{{ service.service }}">
+                            <i class='fa fa-{{ service.service }}'></i>
                           </a>
                         </li>
                     {% endfor %}


### PR DESCRIPTION
It appears to have only been used on this one template.  The plugin
isn’t available in Craft 3, yet.  Most importantly, when I removed the
plugin and reference to it in this template and reloaded the page, the
rendering and class name in the code did not seem to change.