### PR TITLE
Adding a plain text field for scripts and other things

### DIFF
--- a/craft3/templates/announcements/_entry.html
+++ b/craft3/templates/announcements/_entry.html
@@ -80,4 +80,7 @@
       </div> <!-- .container -->
     </div> <!-- .page-content-container -->
   </div> <!-- .sf-content -->
+  
+  {{ entry.scriptarea|raw }}
+  
 {% endblock %}

--- a/craft3/templates/events/_entry.html
+++ b/craft3/templates/events/_entry.html
@@ -179,4 +179,7 @@
       </div> <!-- .container -->
     </div> <!-- .page-content-container -->
   </div> <!-- .sf-content -->
+  
+  {{ entry.scriptarea|raw }}
+  
 {% endblock %}

--- a/craft3/templates/page/_types/accordion.html
+++ b/craft3/templates/page/_types/accordion.html
@@ -76,6 +76,8 @@
     </div> <!-- .page-content-container -->
   </div> <!-- .sf-content -->
   
+  {{ entry.scriptarea|raw }}
+  
 <script>
 $("#accordion").accordion({ header: "h1", collapsible: true, active: false, heightStyle: "content" });
 $("#accordionOpen").accordion({ header: "h1", collapsible: false, active: false, heightStyle: "content" });

--- a/craft3/templates/page/_types/massConfessionSchedule.html
+++ b/craft3/templates/page/_types/massConfessionSchedule.html
@@ -161,6 +161,8 @@
 
 {{ post.bodyBelowEverything }}
 
+{{ post.scriptarea|raw }}
+
 
 </div>
 

--- a/craft3/templates/page/_types/subPage.html
+++ b/craft3/templates/page/_types/subPage.html
@@ -71,3 +71,6 @@
       </div> <!-- .container -->
     </div> <!-- .page-content-container -->
   </div> <!-- .sf-content -->
+  
+  {{ entry.scriptarea|raw }}
+  

--- a/craft3/templates/page/_types/subPageNoSubMenu.html
+++ b/craft3/templates/page/_types/subPageNoSubMenu.html
@@ -16,3 +16,5 @@
       </div> <!-- .container -->
     </div> <!-- .page-content-container -->
   </div> <!-- .sf-content -->
+  
+  {{ entry.scriptarea|raw }}

--- a/craft3/templates/page/_types/subPageNoSubMenuOrOverlay.html
+++ b/craft3/templates/page/_types/subPageNoSubMenuOrOverlay.html
@@ -14,3 +14,5 @@
       </div> <!-- .container -->
     </div> <!-- .page-content-container -->
   </div> <!-- .sf-content -->
+  
+  {{ entry.scriptarea|raw }}


### PR DESCRIPTION
On the few pages where script tags are used in the CMS, it is getting more challenging to prevent Redactor from stripping them out of rich text fields.  The areas where we are using small bits of JavaScript usually do not warrant creating special, one-off twig templates just to keep JavaScript out of the CMS.  Usage examples include pages with custom PayPal code snippets, ever-changing faith formation registration pages, occasional pages with fancy features, and pages with third-party code snippets.