### PR TITLE
Replacing Linkit plugin fields with plain text

### DIFF
--- a/craft3/templates/appPage/_types/bulletin2.html
+++ b/craft3/templates/appPage/_types/bulletin2.html
@@ -161,10 +161,10 @@
                   <div style="margin-top:15px;"><b>{{ person.professionalTitle }}</b></div>
                   <div>{{ person.title|replace('Father', 'Fr.')|replace('Muñoz', 'M.') }}</div>
                   {% if person.phoneNumber is not empty %}
-                      <div>Ph. {{ person.phoneNumber.text }}</div>
+                      <div>Ph. {{ person.phoneNumber }}</div>
                   {% endif %}
                   {% if person.emailAddress is not empty %}
-                      <div>{{ person.emailAddress.text }}</div>
+                      <div>{{ person.emailAddress }}</div>
                   {% endif %}
               </div>
               <div class="priestTilePicture">

--- a/craft3/templates/appPage/_types/bulletinBackPage.html
+++ b/craft3/templates/appPage/_types/bulletinBackPage.html
@@ -56,10 +56,10 @@
               <div class="staffinfo">{{ person.professionalTitle|replace('Catechesis of the Good Shepherd', 'CGS')|replace('Catequesis del Buen Pastor','CBP')|replace('Administration Coordinator', 'Administration') }}:</div>
               <div class="staffinfo">{{ person.title|replace('Deacon', 'Dcn.') }}</div>
               {% if person.phoneNumber is not empty %}
-              <div class="staffinfo">Ph. {{ person.phoneNumber.text }}</div>
+              <div class="staffinfo">Ph. {{ person.phoneNumber }}</div>
               {% endif %}
               {% if person.emailAddress is not empty %}
-                  <div class="staffinfo">{{ person.emailAddress.text }}</div>
+                  <div class="staffinfo">{{ person.emailAddress }}</div>
               {% endif %}
             
           </div> <!-- .staff-member -->

--- a/craft3/templates/page/_types/peopleLanding.html
+++ b/craft3/templates/page/_types/peopleLanding.html
@@ -85,7 +85,7 @@
             </div>
             {% if (person.phoneNumber is not empty) and (not person.hidePhone | length) %}
               <div class="col col-email">
-                <a href="{{ person.phoneNumber.url }}" class="btn btn-sm btn-light-blue"><i class="fa fa-phone"></i> {{ person.phoneNumber.text }}</a>
+                <a href="tel:{{ person.phoneNumber }}" class="btn btn-sm btn-light-blue"><i class="fa fa-phone"></i> {{ person.phoneNumber }}</a>
               </div>
             {% endif %}
             

--- a/craft3/templates/page/_types/staffLanding.html
+++ b/craft3/templates/page/_types/staffLanding.html
@@ -25,11 +25,11 @@
               <span class="job-title">{{ person.professionalTitle }}</span>
             </div>
             {% if person.emailAddress is not empty %}
-              <span id="i-{{ person.slug }}" style="display:none">{{ person.emailAddress.text|hash }}</span>
+              <span id="i-{{ person.slug }}" style="display:none">{{ person.emailAddress|hash }}</span>
             {% endif %}
             {% if (person.phoneNumber is not empty) and (not person.hidePhone | length) %}
               <div class="col col-phone">
-                <a href="{{ person.phoneNumber.url }}" class="btn btn-sm btn-light-blue"><i class="fa fa-phone"></i> {{ person.phoneNumber.text }}</a>
+                <a href="tel:{{ person.phoneNumber }}" class="btn btn-sm btn-light-blue"><i class="fa fa-phone"></i> {{ person.phoneNumber }}</a>
               </div>
             {% endif %}
             {% if (person.emailAddress is not empty) and (not person.hideEmail | length) %}

--- a/craft3/templates/page/_types/vocationsLanding.html
+++ b/craft3/templates/page/_types/vocationsLanding.html
@@ -93,12 +93,12 @@
             </div>
             {% if person.phoneNumber is not empty %}
               <div class="col col-phone">
-                <a href="{{ person.phoneNumber.url }}" class="btn btn-sm btn-light-blue"><i class="fa fa-phone"></i> {{ person.phoneNumber.text }}</a>
+                <a href="tel:{{ person.phoneNumber }}" class="btn btn-sm btn-light-blue"><i class="fa fa-phone"></i> {{ person.phoneNumber }}</a>
               </div>
             {% endif %}
             {% if person.emailAddress is not empty %}
               <div class="col col-email">
-                <a href="{{ person.emailAddress.url }}" class="btn btn-sm btn-light-blue"><i class="fa fa-envelope"></i> Email</a>
+                <a href="mailto:{{ person.emailAddress }}" class="btn btn-sm btn-light-blue"><i class="fa fa-envelope"></i> Email</a>
               </div>
             {% endif %}
             

--- a/craft3/templates/people/_entry.html
+++ b/craft3/templates/people/_entry.html
@@ -37,7 +37,7 @@
             {% if person.phoneNumber is not empty %}
               {% set link = person.phoneNumber %}
               <div class="col col-phone">
-                <a href="tel:{{ person.phoneNumber.tel }}" class="btn btn-sm btn-light-blue"><i class="fa fa-phone"></i> {{ person.phoneNumber.tel }}</a>
+                <a href="tel:{{ person.phoneNumber }}" class="btn btn-sm btn-light-blue"><i class="fa fa-phone"></i> {{ person.phoneNumber }}</a>
               </div>
             {% endif %}
             {% if person.emailAddress is not empty %}


### PR DESCRIPTION
It was good while it lasted.  The basic Craft CMS contains most of what we need, now.