### PR TITLE
Update redirect.twig

### DIFF
--- a/craft3/templates/page/_types/redirect.twig
+++ b/craft3/templates/page/_types/redirect.twig
@@ -1,5 +1,5 @@
-{% if entry.entryLocation|length %}
-    {% redirect entry.entryLocation[0].url %}
+{% if entry.entryLocation.exists() %}
+    {% redirect entry.entryLocation.one().url %}
 {% elseif entry.webUrl|length %}
     {% redirect entry.webUrl %}
 {% elseif entry.redirectUrl|length %}


### PR DESCRIPTION
Minor fix to prevent warnings in Craft CMS.