### PR TITLE
Replacing Recaptcha and replacing a calendar link

### DIFF
--- a/craft3/templates/page/_types/contactUs.html
+++ b/craft3/templates/page/_types/contactUs.html
@@ -104,13 +104,13 @@
                       </div>
                       
                       
-                      <div class="form-row">
-                          {{ craft.recaptcha.render() }}
-                      </div>
+                    
 
                     </div> <!-- .form-group -->
+                    
+                    {{ craft.recaptcha.renderBindButton('stanneFormButton') }}
 
-                    <button type="submit" class="btn btn-lg btn-light-blue btn-full-width"><span class='button__text'>{{ "Send Now"|t }}</span></button>
+                    <button id="stanneFormButton" type="submit" class="btn btn-lg btn-light-blue btn-full-width"><span class='button__text'>{{ "Send Now"|t }}</span></button>
                     <p class="text-center muted">{{ "We are usually able to respond within 1-3 days."|t }}</p>
                   </form>
                 </div> <!-- .contact-form -->

--- a/craft3/templates/page/_types/faqLanding.html
+++ b/craft3/templates/page/_types/faqLanding.html
@@ -66,15 +66,12 @@
                       <div class="form-row">
                         <input type="text" name="message[Phone]" id="message[Phone]" class="input-full-width" placeholder="{{ "Phone Number"|t }}">
                       </div>
-                      
-                      
-                      <div class="form-row">
-                          {{ craft.recaptcha.render() }}
-                      </div>
 
                     </div> <!-- .form-group -->
+                    
+                    {{ craft.recaptcha.renderBindButton('stanneFormButton') }}
 
-                    <button type="submit" class="btn btn-lg btn-light-blue btn-full-width"><span class='button__text'>{{ "Send Now"|t }}</span></button>
+                    <button id="stanneFormButton" type="submit" class="btn btn-lg btn-light-blue btn-full-width"><span class='button__text'>{{ "Send Now"|t }}</span></button>
                     <p class="text-center muted">{{ "We are usually able to respond within 1-3 days."|t }}</p>
                   </form>
                 </div> <!-- .contact-form -->

--- a/craft3/templates/page/_types/staffLanding.html
+++ b/craft3/templates/page/_types/staffLanding.html
@@ -169,13 +169,12 @@
 		<input type="text" name="message[Phone]" id="message[Phone]" class="input-full-width" placeholder="{{ "Phone Number"|t }}">
 	  </div>
 	  
-	  
-	  <div class="form-row">
-		  {{ craft.recaptcha.render() }}
-	  </div>
 
 </div> <!-- .form-group -->
-<button type="submit" class="btn btn-lg btn-light-blue btn-full-width"><span class='button__text'>{{ "Send Now"|t }}</span></button>
+
+{{ craft.recaptcha.renderBindButton('stanneFormButton') }}
+
+<button id="stanneFormButton" type="submit" class="btn btn-lg btn-light-blue btn-full-width"><span class='button__text'>{{ "Send Now"|t }}</span></button>
 <p class="text-center muted">{{ "We are usually able to respond within 1-3 days."|t }}</p>
   
 </form>

--- a/craft3/templates/partials/_nav.twig
+++ b/craft3/templates/partials/_nav.twig
@@ -5,7 +5,7 @@
     {% if craft.app.language == 'en-US' %}
       <ul class="">
         <li><a href="/es" title="En Espa&ntilde;ol"><i class="fa fa-refresh"></i> En Espa&ntilde;ol</a></li>
-        <li><a href="https://facilities.stanneaz.org/Web/view-schedule.php" title="Calendar"><i class="fa fa-calendar"></i> Calendar</a></li>
+        <li><a href="https://facilities.stanneaz.us/Web/view-calendar.php" title="Calendar"><i class="fa fa-calendar"></i> Calendar</a></li>
         <li><a href="https://stanneaz.flocknote.com/login" target='_blank' title="Flocknote"><i class="fa fa-user"></i> Flocknote</a></li>
         <li><a href="https://phoenix.parishsoftfamilysuite.com/Default.aspx" title="My Own Church"><i class="fa fa-heart-o"></i> My Own Church</a></li>
         <li><a href="/about/times" title="Mass Times"><i class="fa fa-clock-o"></i> Mass Times</a></li>
@@ -15,7 +15,7 @@
         
       <ul class="">
         <li><a href="/" title="English"><i class="fa fa-refresh"></i> English</a></li>
-        <li><a href="https://facilities.stanneaz.org/Web/view-schedule.php" title="Calendario"><i class="fa fa-calendar"></i> Calendario</a></li>
+        <li><a href="https://facilities.stanneaz.us/Web/view-calendar.php" title="Calendario"><i class="fa fa-calendar"></i> Calendario</a></li>
         <li><a href="https://stanneaz.flocknote.com/login" target='_blank' title="Flocknote"><i class="fa fa-user"></i> Flocknote</a></li>
         <li><a href="https://phoenix.parishsoftfamilysuite.com/Default.aspx" title="My Own Church"><i class="fa fa-heart-o"></i> My Own Church</a></li>
         <li><a href="/es/about/times" title="Horario de Misas"><i class="fa fa-clock-o"></i> Horario</a></li>


### PR DESCRIPTION
Replaced link to St. Anne Scheduler calendar on _nav.twig.  On contactUs.html, faqLanding.html, and staffLanding.html we are now using Recaptcha 3 instead of Recaptcha 2.