### PR TITLE
New logic for displaying events

### DIFF
--- a/craft3/templates/appPage/_types/rotations.html
+++ b/craft3/templates/appPage/_types/rotations.html
@@ -33,11 +33,11 @@
     -o-transition: opacity 1s;
     transition: opacity 1s;
 }
-.slide .zDate{font-size:32px;padding:0}
-.slide .zTitle{font-size:34px;font-weight:bold;margin-bottom:20px;padding:0}
-.slide h4{font-size:38px; margin:0 0 20px 0; padding:0}
+.slide .zDate{font-size:40px;padding:0}
+.slide .zTitle{font-size:40px;font-weight:bold;margin-bottom:20px;padding:0}
+.slide h4{font-size:40px; margin:0 0 20px 0; padding:0}
 .slide img{margin:0 0 20px 0}
-.slide p, .slide div{font-size:24px;margin:0;padding:0 0 20px 0}
+.slide p, .slide div{font-size:32px;margin:0;padding:0 0 20px 0}
 .showing {
     opacity: 1;
     z-index: 2;
@@ -46,7 +46,7 @@
 
 {{ entry.body }}
 
-{% import 'events/_event-time-variables' as macros %}
+{% import 'events/_event-time-variables2' as macros %}
 
 {% set eMarker = 1 %}
 
@@ -91,9 +91,11 @@
 {% for entry in craft.entries.section('events').orderBy('eventStartDate ASC').limit('80').all() %}
 
 	{% if (entry.eventStartDate|date('Ymd') >= now|date('Ymd')) and (not entry.hideFromDigitalMediaBoards | length) %}
+	
+	{% set curTimeVar = macros.time_options(entry.afterMass, craft.app.language, entry.eventStartDate, entry.eventEndDate, entry.eventCustomDate, entry.tbdTba, entry.showDatesOnly)|replace(' &amp; ',' & ')|replace('\n','')  %}
 
 		<div class="slide">
-	        <div class="zDate">{{ macros.date_time_options(entry.afterMass, craft.app.language, entry.eventStartDate, entry.eventEndDate, entry.eventCustomDate, entry.tbdTba, entry.showDatesOnly)|replace(' &amp; ',' & ') }}</div>
+	        <div class="zDate">{{ macros.date_options(entry.afterMass, craft.app.language, entry.eventStartDate, entry.eventEndDate, entry.eventCustomDate, entry.tbdTba, entry.showDatesOnly)|replace(' &amp; ',' & ') }}{% if (curTimeVar != '0') %}, {{curTimeVar}}{% endif %}</div>
 	        <div class="zTitle">{{ entry.title }}</div>
 	        {% if entry.rotationImage.exists() %}
 	            <img src="{{ entry.rotationImage.one().url }}" alt="" height="200" />

--- a/craft3/templates/events/_event-time-variables2.twig
+++ b/craft3/templates/events/_event-time-variables2.twig
@@ -1,0 +1,97 @@
+{%- macro date_options(afterMass, language, startDate, endDate, eventCustomDate, tbdTba, showDatesOnly) -%}
+{% if language == 'es-US' %}			
+	{% if eventCustomDate | length %}
+        {% set displayD = eventCustomDate %}
+	{% elseif tbdTba | length %}
+	    {% set displayD = "Horario: por determinar" %}  
+	{% elseif startDate|date('F d') == endDate|date('F d') %}
+	    {% set displayD = startDate|date('d F, Y') %}
+	{% elseif (endDate is not empty) and (endDate|date('g:i') != '12:00') %}  
+	    {% if showDatesOnly | length %}
+		    {% set displayD = startDate|date('d F') ~ " a " ~ endDate|date('d F, Y') %}
+	    {% else %}
+		    {% set displayD = startDate|date('d F, Y') ~ " al " ~  endDate|date('d F, Y') %}
+	    {% endif %}             
+	{% else %}
+	    {% set displayD = startDate|date('d F, Y') %}          
+	{% endif %}			
+{% else %}
+	{% if eventCustomDate | length %}
+	    {% set displayD = eventCustomDate %}	
+	{% elseif tbdTba | length %}
+	    {% set displayD = "Date/Time: TBD/TBA" %}
+	{% elseif (afterMass | length) and (endDate is not empty) %}
+	    {% if startDate|date('F d') == endDate|date('F d') %}
+	        {% set displayD = startDate|date('l, F d') %}
+	    {% else %}
+		    {% set displayD = "Saturday & Sunday, " ~ startDate|date('F d') ~ "-" ~ endDate|date('d') %}
+		{% endif %}    
+	{% elseif startDate|date('F d') == endDate|date('F d') %}
+		{% set displayD = startDate|date('l, F d, Y') %}
+	{% elseif (endDate is not empty) and (endDate|date('g:i') != '12:00') %}  
+		{% if showDatesOnly | length %}
+		    {% set displayD = startDate|date('l, F d') ~ " to " ~ endDate|date('l, F d, Y') %}
+		{% else %}
+		    {% set displayD = startDate|date('l, F d, Y g:i A') ~ " to " ~  endDate|date('l, F d, Y g:i A') %}
+		{% endif %}             
+	{% else %}
+		{% set displayD = startDate|date('l, F d, Y') %}          
+	{% endif %}
+{% endif %}
+{% set displayD =  displayD|replace(' 01', ' 1')|replace(' 02', ' 2')|replace(' 03', ' 3')|replace(' 04', ' 4')|replace(' 05', ' 5')|replace(' 06', ' 6')|replace(' 07', ' 7')|replace(' 08', ' 8')|replace(' 09', ' 9')|replace('-01', '-1')|replace('-02', '-2')|replace('-03', '-3')|replace('-04', '-4')|replace('-05', '-5')|replace('-06', '-6')|replace('-07', '-7')|replace('-08', '-8')|replace('-09', '-9') %}
+{{ displayD }}
+{%- endmacro -%}
+{%- macro time_options(afterMass, language, startDate, endDate, eventCustomDate, tbdTba, showDatesOnly) -%}
+{% if language == 'es-US' %}			
+	{% if eventCustomDate | length %}
+        {% if showDatesOnly | length %}
+		    {% set displayT = "0" %}
+	    {% else %}
+		    {% set displayT = startDate|date('g:i') ~ " a " ~ endDate|date('g:i A') %}
+	    {% endif %}	
+	{% elseif tbdTba | length %}
+	    {% set displayT = "0" %}  
+	{% elseif startDate|date('F d') == endDate|date('F d') %}
+	    {% if startDate|date('a') == endDate|date('a') %}
+		    {% set displayT = startDate|date('g:i') ~ " a " ~ endDate|date('g:i A') %}
+	    {% else %}
+		    {% set displayT = startDate|date('g:i A') ~ " a " ~ endDate|date('g:i A') %}
+	    {% endif %}  
+	{% elseif (endDate is not empty) and (endDate|date('g:i') != '12:00') %}  
+	    {% if showDatesOnly | length %}
+		    {% set displayT = "0" %}
+	    {% else %}
+		    {% set displayT = startDate|date('g:i A') ~ " a " ~  endDate|date('g:i A') %}
+	    {% endif %}             
+	{% else %}
+	    {% if showDatesOnly | length %}
+		    {% set displayT = "0" %} 
+	    {% else %}
+		    {% set displayT = startDate|date('g:i A') %}
+	    {% endif %}             
+	{% endif %}			
+{% else %}
+	{% if eventCustomDate | length %}
+	    {% if showDatesOnly | length %}
+		    {% set displayT = "0" %} 
+	    {% else %}
+            {% set displayT = startDate|date('g:i A') ~ " to " ~ endDate|date('g:i A') %}
+        {% endif %}  	
+	{% elseif tbdTba | length %}
+	    {% set displayT = "0" %}
+	{% elseif (afterMass | length) and (endDate is not empty) %}
+	    {% set displayT = "After Mass" %} 
+	{% elseif startDate|date('F d') == endDate|date('F d') %}
+		{% set displayT = startDate|date('g:i A') ~ " to " ~ endDate|date('g:i A') %}
+	{% elseif (endDate is not empty) and (endDate|date('g:i') != '12:00') %}  
+		{% set displayT = "0" %}
+	{% else %}
+		{% if showDatesOnly | length %}
+		    {% set displayT = "0" %}
+		{% else %}
+		    {% set displayT = startDate|date('\\a\\t g:i A') %}
+		{% endif %}             
+	{% endif %}
+{% endif %}
+{{displayT}}
+{%- endmacro -%}

--- a/craft3/templates/index.html
+++ b/craft3/templates/index.html
@@ -165,15 +165,11 @@
         <div class="container news-grid">
       
 <div class="row news-blocks">
-         
-	<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
-		{{ entry.homeBlock1|raw }}
-	</div>  
  
 	<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
 	
-		{% if entry.homeBlock2 %}
-			{{ entry.homeBlock2|raw }}
+		{% if entry.homeBlock1 %}
+			{{ entry.homeBlock1|raw }}
 		{% else %}
 		
 			{% if craft.app.language == 'es-US' %}
@@ -189,7 +185,7 @@
 			{% for post in entries %}
 
 				{% if post.massCancellationMessage%}
-					<b class="cancelledItem">{{ post.massCancellationMessage }}</b><br>
+					<b class="cancelledItem">{{ post.massCancellationMessage|raw }}</b><br>
 				{% endif %}
 	
 				{% if post.sundayMassTimes.exists() %}
@@ -253,7 +249,7 @@
 					{% if post.saturdayVigilMassTimes.exists() %}
 						{% for block in post.saturdayVigilMassTimes.all() %}
 							{% set cDate = block.dateCancelledOrChanged %}
-							{{ block.hourName|replace('in English', '(English)')|replace('in Spanish', '(Spanish)')|replace('en inglés', '(inglés)')|replace('en español', '(español)')|raw}}{% if cDate|length %}{% if cDate|date('Ymd') >= now|date('Ymd') %} <span class="cancelledItem">({% if block.customMessage|length %}{{ block.customMessage }}{% else %}{{cancelledOn}} {% if craft.app.language == 'es-US' %}{{ cDate|date('d \\d\\e F, Y') }}{% else %}{{ cDate|date('F d, Y') }}{% endif %}{% endif %})</span>{% endif %}{% endif %}{% if loop.index == 1 %}, {% endif %}
+							{{ block.hourName|replace('in English', '(Vigil in English)')|replace('in Spanish', '(Vigil in Spanish)')|replace('en inglés', '(inglés)')|replace('en español', '(español)')|raw}}{% if cDate|length %}{% if cDate|date('Ymd') >= now|date('Ymd') %} <span class="cancelledItem">({% if block.customMessage|length %}{{ block.customMessage }}{% else %}{{cancelledOn}} {% if craft.app.language == 'es-US' %}{{ cDate|date('d \\d\\e F, Y') }}{% else %}{{ cDate|date('F d, Y') }}{% endif %}{% endif %})</span>{% endif %}{% endif %}{% if loop.index == 1 %}, {% endif %}
 						{% endfor %}
 					{% endif %}
 				{% endif %}
@@ -273,8 +269,8 @@
 		
 	<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
 		
-    {% if entry.homeBlock3 %}
-        {{ entry.homeBlock3|raw }}
+    {% if entry.homeBlock2 %}
+        {{ entry.homeBlock2|raw }}
     {% else %}
 	
 		{% if craft.app.language == 'es-US' %}
@@ -288,13 +284,13 @@
 		{% for post in entries %}
 
 			{% if post.confessionCancellationMessage%}
-				<b class="cancelledItem">{{ post.confessionCancellationMessage }}</b><br>
+				<b class="cancelledItem">{{ post.confessionCancellationMessage|raw }}</b><br>
 			{% endif %}
 
 		    {% if post.confessionTimes.exists() %}
 				{% for block in post.confessionTimes.all() %}
 					{% set cDate = block.dateCancelledOrChanged %}
-					{{ block.dayAndTimes|replace('Saturday:', '<b>Saturday:</b>')|replace('Sunday:', '<b>Sunday:</b>')|replace('Monday:', '<b>Monday:</b>')|replace('Tuesday:', '<b>Tuesday:</b>')|replace('Wednesday:', '<b>Wednesday:</b>')|replace('Thursday:', '<b>Thursday:</b>')|replace('Friday:', '<b>Friday:</b>')|replace('Lunes:', '<b>Lunes:</b>')|replace('Martes:', '<b>Martes:</b>')|replace('Miércoles:', '<b>Miércoles:</b>')|replace('Jueves:', '<b>Jueves:</b>')|replace('Viernes:', '<b>Viernes:</b>')|replace('Sábado:', '<b>Sábado:</b>')|raw }}{% if cDate|length %}{% if cDate|date('Ymd') >= now|date('Ymd') %} <span class="cancelledItem">({% if block.customMessage|length %}{{ block.customMessage }}{% else %}{{cancelledOn}} {% if craft.app.language == 'es-US' %}{{ cDate|date('d \\d\\e F, Y') }}{% else %}{{ cDate|date('F d, Y') }}{% endif %}{% endif %})</span>{% endif %}{% endif %}<br>
+					{{ block.dayAndTimes|replace('Saturday:', '<b>Saturday:</b>')|replace('Sunday:', '<b>Sunday:</b>')|replace('Monday:', '<b>Monday:</b>')|replace('Tuesday:', '<b>Tuesday:</b>')|replace('Wednesday:', '<b>Wednesday:</b>')|replace('Thursday:', '<b>Thursday:</b>')|replace('Friday:', '<b>Friday:</b>')|replace('Domingo:', '<b>Domingo:</b>')|replace('Lunes:', '<b>Lunes:</b>')|replace('Martes:', '<b>Martes:</b>')|replace('Miércoles:', '<b>Miércoles:</b>')|replace('Jueves:', '<b>Jueves:</b>')|replace('Viernes:', '<b>Viernes:</b>')|replace('Sábado:', '<b>Sábado:</b>')|raw }}{% if cDate|length %}{% if cDate|date('Ymd') >= now|date('Ymd') %} <span class="cancelledItem">({% if block.customMessage|length %}{{ block.customMessage }}{% else %}{{cancelledOn}} {% if craft.app.language == 'es-US' %}{{ cDate|date('d \\d\\e F, Y') }}{% else %}{{ cDate|date('F d, Y') }}{% endif %}{% endif %})</span>{% endif %}{% endif %}<br>
 				{% endfor %}
 		    {% endif %}
 
@@ -309,6 +305,10 @@
     {% endif %}
     
 	</div>
+	
+	<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
+		{{ entry.homeBlock3|raw }}
+	</div>  
 		
 	<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
 		{{ entry.homeBlock4|raw }}

--- a/craft3/templates/page/_types/faqLanding.html
+++ b/craft3/templates/page/_types/faqLanding.html
@@ -35,7 +35,7 @@
 					{% else %}
 						Note:
 					{% endif %}
-					{{ post.massCancellationMessage }}
+					{{ post.massCancellationMessage|raw }}
 				</b><br><br>
 			{% endif %}
 
@@ -134,14 +134,14 @@
 					{% else %}
 						Note:
 					{% endif %}
-					{{ post.confessionCancellationMessage }}
+					{{ post.confessionCancellationMessage|raw }}
 				</b><br><br>
 			{% endif %}
 
 		    {% if post.confessionTimes.exists() %}
 				{% for block in post.confessionTimes.all() %}
 					{% set cDate = block.dateCancelledOrChanged %}
-					{{ block.dayAndTimes|replace('Saturday:', '<b>Saturday:</b>')|replace('Sunday:', '<b>Sunday:</b>')|replace('Monday:', '<b>Monday:</b>')|replace('Tuesday:', '<b>Tuesday:</b>')|replace('Wednesday:', '<b>Wednesday:</b>')|replace('Thursday:', '<b>Thursday:</b>')|replace('Friday:', '<b>Friday:</b>')|replace('Lunes:', '<b>Lunes:</b>')|replace('Martes:', '<b>Martes:</b>')|replace('Miércoles:', '<b>Miércoles:</b>')|replace('Jueves:', '<b>Jueves:</b>')|replace('Viernes:', '<b>Viernes:</b>')|replace('Sábado:', '<b>Sábado:</b>')|raw }}{% if cDate|length %}{% if cDate|date('Ymd') >= now|date('Ymd') %} <span class="cancelledItem">({% if block.customMessage|length %}{{ block.customMessage }}{% else %}{{cancelledOn}} {% if craft.app.language == 'es-US' %}{{ cDate|date('d \\d\\e F, Y') }}{% else %}{{ cDate|date('F d, Y') }}{% endif %}{% endif %})</span>{% endif %}{% endif %}<br>
+					{{ block.dayAndTimes|replace('Saturday:', '<b>Saturday:</b>')|replace('Sunday:', '<b>Sunday:</b>')|replace('Monday:', '<b>Monday:</b>')|replace('Tuesday:', '<b>Tuesday:</b>')|replace('Wednesday:', '<b>Wednesday:</b>')|replace('Thursday:', '<b>Thursday:</b>')|replace('Friday:', '<b>Friday:</b>')|replace('Domingo:', '<b>Domingo:</b>')|replace('Lunes:', '<b>Lunes:</b>')|replace('Martes:', '<b>Martes:</b>')|replace('Miércoles:', '<b>Miércoles:</b>')|replace('Jueves:', '<b>Jueves:</b>')|replace('Viernes:', '<b>Viernes:</b>')|replace('Sábado:', '<b>Sábado:</b>')|raw }}{% if cDate|length %}{% if cDate|date('Ymd') >= now|date('Ymd') %} <span class="cancelledItem">({% if block.customMessage|length %}{{ block.customMessage }}{% else %}{{cancelledOn}} {% if craft.app.language == 'es-US' %}{{ cDate|date('d \\d\\e F, Y') }}{% else %}{{ cDate|date('F d, Y') }}{% endif %}{% endif %})</span>{% endif %}{% endif %}<br>
 				{% endfor %}
 		    {% endif %}
 

--- a/craft3/templates/page/_types/holyDays.html
+++ b/craft3/templates/page/_types/holyDays.html
@@ -15,6 +15,47 @@
 
     <div class="page-content-container">
       <div class="container standard-container">
+      
+        {{ post.bodyb }}
+        
+        {% import 'events/_event-time-variables2' as macros %}
+        {% for entry in craft.entries.section('events').orderBy('eventStartDate ASC').limit('80').all() %}
+            {% if (entry.eventStartDate|date('Ymd') >= now|date('Ymd')) and (entry.displayOnSeasonalPage | length) %}
+             
+                {% if entry.pageImage.exists() %}
+	                <img src="{{ entry.pageImage.one().url }}" alt="{{ entry.title }}" width="100%" />
+	            {% elseif entry.rotationImage.exists() %}
+	                <img src="{{ entry.rotationImage.one().url }}" alt="{{ entry.title }}" width="100%" />
+	            {% else %}
+	                {% if entry.eventListingImage.exists() %}
+	                    <img src="{{ entry.eventListingImage.one().url }}" alt="" width="321" height="200" />
+	                {% endif %}
+	            {% endif %}
+	            
+	            <h3>{{ entry.title }}, {{ macros.date_options(entry.afterMass, craft.app.language, entry.eventStartDate, entry.eventEndDate, entry.eventCustomDate, entry.tbdTba, entry.showDatesOnly)|replace(' &amp; ',' & ') }}</h3>
+	            {% set curTimeVar = macros.time_options(entry.afterMass, craft.app.language, entry.eventStartDate, entry.eventEndDate, entry.eventCustomDate, entry.tbdTba, entry.showDatesOnly)|replace(' &amp; ',' & ')|replace('\n','')|replace('\t','')|replace('\s','')  %}
+				<p><b>{% if (curTimeVar != '0') %}{{curTimeVar}}{% endif %}</b></p>
+				{% if entry.useLongDescription|length  %}
+				    <p>
+				        {{ entry.body|raw }}
+					</p>
+				{% elseif entry.shortDescription|length  %}
+					<p>{{ entry.shortDescription|raw }}</p>
+				{% else %}
+					{% if entry.body|length < 650 %}
+						<p>{{ entry.body|raw }}</p>
+					{% else %}
+						<p>
+							{{ entry.body|slice(0, 650)|striptags|raw }}...<a href="{{entry.url}}">Read More</a>
+						</p>
+					{% endif %}
+				{% endif %}
+				<p><br></p>
+            
+            
+            {% endif %}
+        {% endfor %}
+      
         {{ post.body }}
         
         {{ post.scriptarea|raw }}

--- a/craft3/templates/page/_types/massConfessionSchedule.html
+++ b/craft3/templates/page/_types/massConfessionSchedule.html
@@ -33,15 +33,20 @@
         {% endif %}
         
 <div class="massConfessionPage">
-    <div id="topMessageArea">
+
 {% if post.topOfPageMessage | length %}
-        {% if craft.app.language == 'es-US' %}
-            <p class="cancelledItem">Hay cambios en el horario. Desplácese hacia abajo para ver los cambios.</p>
-        {% else %}
-            <p class="cancelledItem">There are changes to the schedule.  Scroll down to see the changes.</p>
-        {% endif %}
+    </div>
+    {% if post.massCancellationMessage%}
+		<p class="cancelledItem">
+			{{ post.massCancellationMessage|raw }}
+		</p>
+	{% endif %}
+	{% if post.confessionCancellationMessage%}
+		<p class="cancelledItem">
+			{{ post.confessionCancellationMessage|raw }}
+		</p>
+	{% endif %}  
 {% endif %}
-    </div>     
         
 {{ post.body }}
         
@@ -144,7 +149,7 @@
     <ul>
         {% for block in post.confessionTimes.all() %}
             {% set cDate = block.dateCancelledOrChanged %}
-            <li>{{ block.dayAndTimes }}{% if cDate|length %}{% if cDate|date('Ymd') >= now|date('Ymd') %} <span class="cancelledItem">({% if block.customMessage|length %}{{ block.customMessage }}{% else %}{{cancelledOn}} {% if craft.app.language == 'es-US' %}{{ cDate|date('d \\d\\e F, Y') }}{% else %}{{ cDate|date('F d, Y') }}{% endif %}{% endif %})</span><script>topMessageDateActive=true</script>{% endif %}{% endif %}</li>
+            <li>{{ block.dayAndTimes|replace('Saturday:', '<b>Saturday:</b>')|replace('Sunday:', '<b>Sunday:</b>')|replace('Monday:', '<b>Monday:</b>')|replace('Tuesday:', '<b>Tuesday:</b>')|replace('Wednesday:', '<b>Wednesday:</b>')|replace('Thursday:', '<b>Thursday:</b>')|replace('Friday:', '<b>Friday:</b>')|replace('Domingo:', '<b>Domingo:</b>')|replace('Lunes:', '<b>Lunes:</b>')|replace('Martes:', '<b>Martes:</b>')|replace('Miércoles:', '<b>Miércoles:</b>')|replace('Jueves:', '<b>Jueves:</b>')|replace('Viernes:', '<b>Viernes:</b>')|replace('Sábado:', '<b>Sábado:</b>')|raw }}{% if cDate|length %}{% if cDate|date('Ymd') >= now|date('Ymd') %} <span class="cancelledItem">({% if block.customMessage|length %}{{ block.customMessage }}{% else %}{{cancelledOn}} {% if craft.app.language == 'es-US' %}{{ cDate|date('d \\d\\e F, Y') }}{% else %}{{ cDate|date('F d, Y') }}{% endif %}{% endif %})</span><script>topMessageDateActive=true</script>{% endif %}{% endif %}</li>
         {% endfor %}
     </ul>
 {% endif %}


### PR DESCRIPTION
- holyDays.html displays channel pages from the holyDays channel in St. Anne's Craft CMS.  The channel pages also display a list of events from the events channel that have the Seasonal Event box checked.  It's a new way of taking events from the Events channel and combining them with other parish information pertinent to a given season.  The events displayed on the page disappear after they have expired, and the seasonal page can expire and be replaced by a different seasonal page when information changes.
- rotations.html displays announcements from the announcements channel and events from the events channel onto our parish's media boards.
- _event-time-variables2.twig - I will eventually change pages that use _event-time-variables.twig and merge it this file.  Currently, rotations.html and holyDays.html are the only ones that use it.
- Bug fixes for index.html, MassConfessionSchedule.html, and faqLanding.html